### PR TITLE
Switch to freedesktop 21.08 runtime

### DIFF
--- a/com.github.qarmin.szyszka.yaml
+++ b/com.github.qarmin.szyszka.yaml
@@ -1,7 +1,7 @@
 app-id: com.github.qarmin.szyszka
-runtime: org.gnome.Platform
-runtime-version: '40'
-sdk: org.gnome.Sdk
+runtime: org.freedesktop.Platform
+runtime-version: '21.08'
+sdk: org.freedesktop.Sdk
 sdk-extensions:
 - org.freedesktop.Sdk.Extension.rust-stable
 command: szyszka


### PR DESCRIPTION
```
Info: org.gnome.Platform//40 is end-of-life, with reason:
   The GNOME 40 runtime is no longer supported as of March 21, 2022. Please ask your application developer to migrate to a supported platform.
```
Just like Czkawka, there is no reason to use GNOME runtime instead of just FreeDesktop.