### PR TITLE
bump gnome runtime to v46

### DIFF
--- a/com.github.qarmin.szyszka.yaml
+++ b/com.github.qarmin.szyszka.yaml
@@ -9,7 +9,7 @@ finish-args:
 - "--share=ipc"
 - "--socket=fallback-x11"
 - "--socket=wayland"
-- "--filesystem=/home"
+- "--filesystem=home"
 - "--filesystem=/mnt"
 - "--filesystem=/media"
 - "--filesystem=/run/media"

--- a/com.github.qarmin.szyszka.yaml
+++ b/com.github.qarmin.szyszka.yaml
@@ -1,6 +1,6 @@
 app-id: com.github.qarmin.szyszka
 runtime: org.gnome.Platform
-runtime-version: '44'
+runtime-version: '46'
 sdk: org.gnome.Sdk
 sdk-extensions:
 - org.freedesktop.Sdk.Extension.rust-stable


### PR DESCRIPTION
The GNOME 44 runtime is no longer supported as of March 20, 2024.
Closes https://github.com/qarmin/szyszka/issues/88

Fixes https://docs.flathub.org/docs/for-app-authors/linter/#finish-args-absolute-home-path