### PR TITLE
bump runtime to GNOME 47

### DIFF
--- a/com.github.qarmin.szyszka.yaml
+++ b/com.github.qarmin.szyszka.yaml
@@ -1,6 +1,6 @@
 app-id: com.github.qarmin.szyszka
 runtime: org.gnome.Platform
-runtime-version: '46'
+runtime-version: '47'
 sdk: org.gnome.Sdk
 sdk-extensions:
 - org.freedesktop.Sdk.Extension.rust-stable


### PR DESCRIPTION
tested with:
`flatpak run --runtime-version=47 com.github.qarmin.szyszka`