### PR TITLE
chore: bump runtime to gnome 48

### DIFF
--- a/com.github.qarmin.szyszka.yaml
+++ b/com.github.qarmin.szyszka.yaml
@@ -1,6 +1,6 @@
 app-id: com.github.qarmin.szyszka
 runtime: org.gnome.Platform
-runtime-version: '47'
+runtime-version: '48'
 sdk: org.gnome.Sdk
 sdk-extensions:
 - org.freedesktop.Sdk.Extension.rust-stable


### PR DESCRIPTION
tested with `flatpak run --runtime-version=48 com.github.qarmin.szyszka `